### PR TITLE
Fix "process exited with code: 1" error due to incorrect python path

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -6,7 +6,7 @@ const path = require("path");
 const os = require("os");
 const fs = require("fs");
 
-async function getBestPythonPath() {
+function getBestPythonPath() {
   // Check if Python extension is installed and active
   const pythonExtension = vscode.extensions.getExtension("ms-python.python");
 
@@ -16,6 +16,11 @@ async function getBestPythonPath() {
 
     if (pythonPathFromExtension) {
       return pythonPathFromExtension;
+    }
+
+    if (pythonExtension.exports.settings.getExecutionDetails) {
+      const pythonPathFromActiveDocument = pythonExtension.exports.settings.getExecutionDetails(vscode.window.activeTextEditor.document.uri).execCommand[0];
+      return pythonPathFromActiveDocument;
     }
   }
 
@@ -65,13 +70,7 @@ function runScalene(currentFilePath, context) {
   fs.mkdirSync(tempDir);
 
   const outputFilename = `${tempDir}/profile-${process.pid}.html`;
-
-  let executablePath = "python3";
-
-  (async () => {
-    executablePath = await getBestPythonPath();
-  })();
-
+  const executablePath = getBestPythonPath();
   const args = [
     "-m",
     "scalene",


### PR DESCRIPTION
Before this change, I was unable to use the extension without receiving a popup in VS Code with the error "Scalene: process exited with code: 1".

This was happening because the extension was using the default `python3` path instead of the path to python running in my poetry virtual environment (which is where scalene was installed).

My fix is to add a fallback where the python path is retrieved via the VS Code python extension for the currently active document's python interpreter.

The `async` call also seemed to result in a race condition where the return value from `getBestPythonPath` wasn't always used when calling `child_process.spawn`, so I made this synchronous. I'm not fluent in JS, so let me know if I didn't understand the use of `async` here.

Related to plasma-umass/scalene#706